### PR TITLE
Add types to repo config in test.exs

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -14,6 +14,7 @@ config :logger, level: :warn
 # Configure your database
 config :open_pantry, OpenPantry.Repo,
   adapter: Ecto.Adapters.Postgres,
+  types: OpenPantry.PostgresTypes,  
   username: "postgres",
   password: "postgres",
   database: "open_pantry_test",


### PR DESCRIPTION
connects to bryanjos/geo#65

@bglusman I tried running this locally and added this line and seemed to remove the error about geometry not being handled