### PR TITLE
Remove manual take_screenshot invocations from e2e test

### DIFF
--- a/test/acceptance/food_selection_test.exs
+++ b/test/acceptance/food_selection_test.exs
@@ -51,10 +51,8 @@ defmodule OpenPantry.FoodSelectionTest do
     session = visit(session, "/en/food_selections")
 
     {before_stock, before_requested} = {stock_available(session), stock_requested(session)}
-    take_screenshot session
     session = click_button(session, "+")
     Process.sleep(500)
-    take_screenshot session
     {after_stock, after_requested} = {stock_available(session), stock_requested(session)}
 
     assert (before_stock - after_stock) == 1


### PR DESCRIPTION
Hey @bglusman, was just perusing the codebase and saw these laying around. This change should keep the screenshots directory from ballooning over time.