### PR TITLE
Use travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: elixir
+elixir:
+  - 1.4.0
+otp_release:
+  - 19.0
+addons:
+  postgresql: '9.4'
+services:
+  - postgresql
+before_install:
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
+  - export CHROMEDRIVER_BINARY=/usr/bin/chromium-browser
+  - export CHROMEDRIVER_ARGS=--no-sandbox
+  - /usr/bin/chromium-browser --version
+
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+before_script:
+  - cp config/travis.exs config/test.exs
+  - mix do ecto.create, ecto.migrate
+  - nvm install 7
+  - nvm use 7
+  - cd assets && npm install -g yarn && yarn && cd ..
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/bglusman/open_pantry.svg?branch=master)](https://travis-ci.org/bglusman/open_pantry)
 # OpenPantry
 ## A management system for pantry programs to help people eat healthy meals with dignity
 

--- a/config/travis.exs
+++ b/config/travis.exs
@@ -1,0 +1,39 @@
+use Mix.Config
+
+defmodule Ownership do
+  def timeout do
+    try do
+      String.to_integer(System.get_env("DB_TIMEOUT"))
+    rescue
+      ArgumentError -> 25_000
+    end
+  end
+end
+
+# We don't run a server during test. If one is required,
+# you can enable the server option below.
+config :open_pantry, OpenPantry.Web.Endpoint,
+  http: [port: 4001],
+  server: true
+
+config :open_pantry, :sql_sandbox, true
+
+# Print only warnings and errors during test
+config :logger, level: :warn
+
+# Configure your database
+config :open_pantry, OpenPantry.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  types: OpenPantry.PostgresTypes,
+  username: "postgres",
+  password: "",
+  database: "open_pantry_test",
+  hostname: "localhost",
+  ownership_timeout: Ownership.timeout,
+  pool: Ecto.Adapters.SQL.Sandbox
+
+config :wallaby,
+  max_wait_time: 5_000,
+  screenshot_on_failure: true,
+  js_errors: true,
+  js_logger: :stdio


### PR DESCRIPTION
bump npm version via nvm

Add TRAVIS CI badge, for now pointing to my fork

@nandajavarma FYI I decided to just try this on Travis instead of CircleCI and it's working there now, so I think no need to figure out Circle, can just use this as our CI unless you're super into figuring this out :-)  Also FYI @net, once @komizutama gives me org access or sets up travis for the main repository we can switch this built button to show status there, but for now it runs on my branch and I can just keep it up to date.