### PR TITLE
Set mix to use correct elixir version?  Because, it should?  Why not …

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OpenPantry.Mixfile do
   def project do
     [app: :open_pantry,
      version: "0.0.1",
-     elixir: "~> 1.2",
+     elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
      build_embedded: Mix.env == :prod,


### PR DESCRIPTION
…an issue before?

I wonder if this would have prevented/alerted about @ibrand's issue with brew installing wrong version?