### PR TITLE
Delete StockDistribution elements when quantity is set to zero.

### DIFF
--- a/assets/js/facility.js
+++ b/assets/js/facility.js
@@ -1,5 +1,5 @@
 export default function(channel){
-  const intFromFindClass = (parent, className) => parseInt(parent.find(className).html(), 10)
+  const intFromFindClass = (parent, className) => parseInt(parent.find(className).html(), 10) || 0
   const getMaxAllowed    = (row) => parseInt(row.data('max-allowed'), 10)
   const getStockQuantity = (row) => parseInt(row.data('stock-available'), 10)
   const getAvailable     = (row) => intFromFindClass(row, '.js-available-quantity')
@@ -96,7 +96,7 @@ export default function(channel){
     const {id, html} = payload;
     const $html = $(html)
     const existing = $('.js-cart').find(`*[data-stock-distribution-id="${id}"]`).first();
-    const quantity = intFromFindClass($html, '.js-quantity-requested') || 0;
+    const quantity = intFromFindClass($html, '.js-quantity-requested')
 
     if (existing.length && quantity > 0) {
       $(existing).html($html.html())

--- a/assets/js/facility.js
+++ b/assets/js/facility.js
@@ -96,7 +96,7 @@ export default function(channel){
     const {id, html} = payload;
     const $html = $(html)
     const existing = $('.js-cart').find(`*[data-stock-distribution-id="${id}"]`).first();
-    const quantity = intFromFindClass($html, '.js-quantity-requested')
+    const quantity = intFromFindClass($html, '.js-quantity-requested') || 0;
 
     if (existing.length && quantity > 0) {
       $(existing).html($html.html())

--- a/lib/open_pantry/web/views/shared_view.ex
+++ b/lib/open_pantry/web/views/shared_view.ex
@@ -11,7 +11,11 @@ defmodule OpenPantry.Web.SharedView do
     Renders a distribution line item for food selection index, or to send update to same page via channel
   """
   def render_distribution(%StockDistribution{id: id}) do
-    render_to_string(__MODULE__, "distribution.html", distribution: StockDistribution.find(id, [:stock]))
+    try do
+      render_to_string(__MODULE__, "distribution.html", distribution: StockDistribution.find(id, [:stock]))
+    rescue
+      Ecto.NoResultsError -> ""
+    end
   end
 
   @doc """


### PR DESCRIPTION
Tentative pull request to fix Issue #135 

StockDistribution elements are now automatically deleted when their quantity gets set to zero.
This should remove them from the finalized order.

Please review these changes since I'm not 100% sure how the system is supposed to work.