### PR TITLE
Add a custom scope sorted by food name to the Stock index page.

### DIFF
--- a/lib/open_pantry/admin/stock.ex
+++ b/lib/open_pantry/admin/stock.ex
@@ -22,9 +22,20 @@ defmodule OpenPantry.ExAdmin.Stock do
         input stock, :food, collection: OpenPantry.Food.all
         input stock, :facility, collection: Facility.all
       end
-
-
     end
+
+    scope :sorted_by_food, [default: true], fn(query) ->
+      case query do
+        %Ecto.Query{} ->
+          query
+          |> exclude(:order_by)
+          |> join(:left, [s], f in assoc(s, :food))
+          |> order_by([s, f], asc: f.longdesc)
+        _ ->
+          query
+      end
+    end
+    scope :all, default: false
   end
 
   def display_name(stock) do

--- a/lib/open_pantry/web/controllers/stock_controller.ex
+++ b/lib/open_pantry/web/controllers/stock_controller.ex
@@ -4,7 +4,20 @@ defmodule OpenPantry.Web.StockController do
   alias OpenPantry.Stock
 
   def index(conn, _params) do
-    stocks = Repo.all(Stock)
+    stocks =
+      from(stock in Stock,
+        left_join: food in assoc(stock, :food),
+        left_join: meal in assoc(stock, :meal),
+        left_join: offer in assoc(stock, :offer),
+        order_by: fragment("coalesce(?, '') || coalesce(?, '') || coalesce(?, '') || coalesce(?, '')",
+          stock.override_text,
+          food.longdesc,
+          meal.description,
+          offer.description
+        ),
+        preload: [:food, :meal, :offer]
+      )
+      |> Repo.all()
     render(conn, "index.html", stocks: stocks)
   end
 

--- a/lib/open_pantry/web/models/stock.ex
+++ b/lib/open_pantry/web/models/stock.ex
@@ -55,7 +55,7 @@ defmodule OpenPantry.Stock do
   @spec stock_description(Stock.t) :: String.t
   def stock_description(stock) do
     loaded_stock = stockable_load(stock)
-    (loaded_stock.food && loaded_stock.override_text || loaded_stock.food.longdesc)    ||
+    (loaded_stock.food && (loaded_stock.override_text || loaded_stock.food.longdesc))    ||
     (loaded_stock.meal && loaded_stock.meal.description)                               ||
     (loaded_stock.offer && loaded_stock.offer.description)
   end


### PR DESCRIPTION
This fixes issue #136 by adding a custom scope where stock items are sorted by food name.

I could not add column sorting to the Food column because sorting on association columns isn't supported by ex_admin : https://github.com/smpallen99/ex_admin/issues/144

I'm not completely satisfied by this solution because custom sorting is ignored when in the "Sorted by food" scope.
I'll try to find a way to make custom sorting work in this special scope.