### PR TITLE
Facility from subdomain

### DIFF
--- a/lib/open_pantry/plugs/authentication.ex
+++ b/lib/open_pantry/plugs/authentication.ex
@@ -1,4 +1,4 @@
-defmodule OpenPantry.Authentication do
+defmodule OpenPantry.Plugs.Authentication do
   @authentication Application.get_env(:open_pantry, :admin_authentication)
   def init(opts) do
     @authentication.init(opts)

--- a/lib/open_pantry/plugs/facility.ex
+++ b/lib/open_pantry/plugs/facility.ex
@@ -1,0 +1,20 @@
+defmodule OpenPantry.Plugs.Facility do
+  alias OpenPantry.{Repo, Facility}
+
+  def init(_opts) do
+    Application.get_env(:open_pantry, OpenPantry.Web.Endpoint)[:url][:host]
+    |> String.length()
+  end
+
+  def call(conn, domain_length) do
+    subdomain = subdomain(conn.host, domain_length)
+    facility = Repo.get_by!(Facility, subdomain: subdomain)
+
+    Plug.Conn.assign(conn, :facility, facility)
+  end
+
+  defp subdomain(host, domain_length) do
+    to = -domain_length - 2
+    String.slice(host, 0..to)
+  end
+end

--- a/lib/open_pantry/plugs/facility.ex
+++ b/lib/open_pantry/plugs/facility.ex
@@ -1,4 +1,6 @@
 defmodule OpenPantry.Plugs.Facility do
+  import Ecto.Query, only: [from: 2]
+
   alias OpenPantry.{Repo, Facility}
 
   def init(_opts) do
@@ -8,7 +10,12 @@ defmodule OpenPantry.Plugs.Facility do
 
   def call(conn, domain_length) do
     subdomain = subdomain(conn.host, domain_length)
-    facility = Repo.get_by!(Facility, subdomain: subdomain)
+
+    facility =
+      case Repo.get_by(Facility, subdomain: subdomain) do
+        nil -> Repo.one!(from Facility, limit: 1)
+        facility -> facility
+      end
 
     Plug.Conn.assign(conn, :facility, facility)
   end

--- a/lib/open_pantry/plugs/facility.ex
+++ b/lib/open_pantry/plugs/facility.ex
@@ -4,15 +4,11 @@ defmodule OpenPantry.Plugs.Facility do
   alias OpenPantry.{Repo, Facility}
 
   def init(_opts) do
-    Application.get_env(:open_pantry, OpenPantry.Web.Endpoint)[:url][:host]
-    |> String.length()
   end
 
-  def call(conn, domain_length) do
-    subdomain = subdomain(conn.host, domain_length)
-
+  def call(conn, _opts) do
     facility =
-      case Repo.get_by(Facility, subdomain: subdomain) do
+      case Repo.get_by(Facility, subdomain: subdomain(conn.host)) do
         nil -> Repo.one!(from Facility, limit: 1)
         facility -> facility
       end
@@ -20,8 +16,9 @@ defmodule OpenPantry.Plugs.Facility do
     Plug.Conn.assign(conn, :facility, facility)
   end
 
-  defp subdomain(host, domain_length) do
-    to = -domain_length - 2
-    String.slice(host, 0..to)
+  defp subdomain(host) do
+    host
+    |> String.split(".")
+    |> hd()
   end
 end

--- a/lib/open_pantry/plugs/locale.ex
+++ b/lib/open_pantry/plugs/locale.ex
@@ -1,5 +1,5 @@
 # based on http://code.parent.co/practical-i18n-with-phoenix-and-elixir/
-defmodule OpenPantry.Plug.Locale do
+defmodule OpenPantry.Plugs.Locale do
   import Plug.Conn
 
   def init(default), do: default

--- a/lib/open_pantry/plugs/setup_user.ex
+++ b/lib/open_pantry/plugs/setup_user.ex
@@ -1,4 +1,4 @@
-defmodule OpenPantry.Plug.SetupUser do
+defmodule OpenPantry.Plugs.SetupUser do
   alias OpenPantry.User
   alias OpenPantry.Repo
   alias OpenPantry.Web.UserSelectionView

--- a/lib/open_pantry/web/controllers/user_selection_controller.ex
+++ b/lib/open_pantry/web/controllers/user_selection_controller.ex
@@ -3,7 +3,6 @@ defmodule OpenPantry.Web.UserSelectionController do
   alias OpenPantry.User
   alias OpenPantry.CreditType
   alias OpenPantry.UserCredit
-  alias OpenPantry.Facility
   import OpenPantry.Web.UserSelectionView, only: [login_token: 1]
   @unknown_language_id 184
 

--- a/lib/open_pantry/web/controllers/user_selection_controller.ex
+++ b/lib/open_pantry/web/controllers/user_selection_controller.ex
@@ -5,11 +5,10 @@ defmodule OpenPantry.Web.UserSelectionController do
   alias OpenPantry.UserCredit
   alias OpenPantry.Facility
   import OpenPantry.Web.UserSelectionView, only: [login_token: 1]
-  @hardcoded_facility_id 1
   @unknown_language_id 184
 
   def index(conn, _params) do
-    facility = Facility.find(@hardcoded_facility_id, :users)
+    facility = facility(conn) |> Repo.preload(:users)
     render conn, "index.html",  users: facility.users, conn: conn, changeset: User.changeset(%User{})
   end
 
@@ -22,7 +21,7 @@ defmodule OpenPantry.Web.UserSelectionController do
     user =  User.changeset(%User{}, %{name: name_from_params(params),
                                       family_members: family_members_from_params(params),
                                       primary_language_id: @unknown_language_id,
-                                      facility_id: @hardcoded_facility_id,
+                                      facility_id: facility(conn).id,
                                      })
             |> Repo.insert!()
 
@@ -48,6 +47,10 @@ defmodule OpenPantry.Web.UserSelectionController do
     else
       String.to_integer(params["user"]["family_members"])
     end
+  end
+
+  defp facility(conn) do
+    conn.assigns[:facility]
   end
 
 

--- a/lib/open_pantry/web/models/facility.ex
+++ b/lib/open_pantry/web/models/facility.ex
@@ -2,6 +2,7 @@ defmodule OpenPantry.Facility do
   use OpenPantry.Web, :model
   schema "facilities" do
     field :name, :string
+    field :subdomain, :string
     field :address1, :string
     field :address2, :string
     field :city, :string
@@ -23,8 +24,9 @@ defmodule OpenPantry.Facility do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:name, :address1, :address2, :city, :region, :postal_code, :max_occupancy, :square_meterage_storage])
+    |> cast(params, [:name, :subdomain, :address1, :address2, :city, :region, :postal_code, :max_occupancy, :square_meterage_storage])
     |> unique_constraint(:name)
+    |> unique_constraint(:subdomain)
     |> validate_required([:name])
   end
 

--- a/lib/open_pantry/web/router.ex
+++ b/lib/open_pantry/web/router.ex
@@ -1,9 +1,8 @@
 defmodule OpenPantry.Web.Router do
-  alias OpenPantry.Authentication
-  alias OpenPantry.Plug.SetupUser
-  alias OpenPantry.Plug.Locale
   use OpenPantry.Web, :router
   use ExAdmin.Router
+
+  alias OpenPantry.Plugs
 
   pipeline :browser do
     plug :accepts, ["html"]
@@ -11,11 +10,12 @@ defmodule OpenPantry.Web.Router do
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug Plugs.Facility
   end
 
   pipeline :localized_browser do
     plug :browser
-    plug Locale, "en"
+    plug Plugs.Locale, "en"
   end
 
   pipeline :api do
@@ -23,11 +23,11 @@ defmodule OpenPantry.Web.Router do
   end
 
   pipeline :admin_auth do
-    plug Authentication, use_config: {:open_pantry, :admin_auth}
+    plug Plugs.Authentication, use_config: {:open_pantry, :admin_auth}
   end
 
   pipeline :user_required do
-    plug SetupUser, redirect_url: "/user_selections"
+    plug Plugs.SetupUser, redirect_url: "/user_selections"
   end
 
   scope "/admin", ExAdmin do

--- a/lib/open_pantry/web/router.ex
+++ b/lib/open_pantry/web/router.ex
@@ -10,6 +10,9 @@ defmodule OpenPantry.Web.Router do
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+  end
+
+  pipeline :facility_specified do
     plug Plugs.Facility
   end
 
@@ -43,11 +46,9 @@ defmodule OpenPantry.Web.Router do
   end
 
   scope "/", OpenPantry.Web do
-    pipe_through [:browser, :admin_auth]
+    pipe_through [:browser, :facility_specified, :admin_auth]
     resources "/user_selections", UserSelectionController
   end
-
-
 
   scope "/", OpenPantry.Web do
     pipe_through [:browser]
@@ -56,14 +57,14 @@ defmodule OpenPantry.Web.Router do
   end
 
   scope "/", OpenPantry.Web do
-    pipe_through [:localized_browser] # Use the default browser stack
+    pipe_through [:localized_browser, :facility_specified] # Use the default browser stack
 
     get "/", PageController, :unused
   end
 
 
   scope "/:locale", OpenPantry.Web do
-    pipe_through [:localized_browser, :user_required]
+    pipe_through [:localized_browser, :facility_specified, :user_required]
 
     get "/", PageController, :index
     get "/styleguide", StyleController, :index

--- a/priv/repo/migrations/20170831003932_add_subdomains_to_facilities.exs
+++ b/priv/repo/migrations/20170831003932_add_subdomains_to_facilities.exs
@@ -1,0 +1,11 @@
+defmodule OpenPantry.Repo.Migrations.AddSubdomainsToFacilities do
+  use Ecto.Migration
+
+  def change do
+    alter table(:facilities) do
+      add :subdomain, :string
+    end
+
+    create unique_index(:facilities, [:subdomain])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -20,6 +20,7 @@ import OpenPantry.Factory
 
 facility_params = [
   %{name: "Flatbush",
+    subdomain: "flatbush",
     max_occupancy: 100,
     address1: "1372 Coney Island Ave",
     city: "Brooklyn",
@@ -27,6 +28,7 @@ facility_params = [
     postal_code: "11230"
     },
   %{name: "Boro Park",
+    subdomain: "boro-park",
     max_occupancy: 20,
     address1: "5402 New Utrecht Ave",
     city: "Brooklyn",
@@ -34,6 +36,7 @@ facility_params = [
     postal_code: "11219"
     },
   %{name: "Queens",
+    subdomain: "queens",
     max_occupancy: 50,
     address1: "98-08 Queens Blvd",
     city: "Queens",


### PR DESCRIPTION
@fcapovilla / @komizutama / @net we could merge this as is but may want to build some new index pages for finding all facilities and/or scope /manage/stocks to the current facility etc, but this works locally provided you add the subdomains used to /etc/hosts, and defaults to same first facility in most cases as it does at present.

Thanks to @net for starting this off a couple months ago, we're planning to start hosting the app at openpantry.io soon and using subdomains there, plus perhaps hosting an informational page at the app root/www.  Since there's so much focus on food and pantries/soup kitchens around Thanksgiving, we're hoping maybe we can make a push to get a usable v1 in front of some extra users around/before Thanksgiving, or perhaps between Thanksgiving and Christmas.  You've done a bunch of amazing and valuable work recently @fcapovilla , if you think you have some additional time available in that timeframe it may help us meet some milestones!  I'm hoping I'll have more time the next couple weeks also.  Things are still rudimentary, but hopefully we can prioritize next steps and get this in front of some real users to figure out how far we have to go.  Maybe next step from here is having a basic-auth password per subdomain, instead of globally, so a couple facilities can manage themselves without stepping on each other?  Not sure, @komizutama looking at you here.

