### PR TITLE
Fixes max_per_person and max_per_package validations

### DIFF
--- a/assets/js/facility.js
+++ b/assets/js/facility.js
@@ -39,9 +39,14 @@ export default function(channel){
     const credits = getCredits($row);
     const cost    = getCost($row);
     if (getAvailable($row) > 0 && credits >= cost) {
-      channel.push('request_stock', { id: $row.data('stock-id'), quantity: 1, type: getType($row) });
-      setUserQuantity($row, getQuantity($row) + 1);
-      setCredits($row, credits - cost);
+      channel.push('request_stock', { id: $row.data('stock-id'), quantity: 1, type: getType($row) })
+        .receive("ok", function() {
+          setUserQuantity($row, getQuantity($row) + 1);
+          setCredits($row, credits - cost);
+        })
+        .receive("error", function() {
+          // TODO: Manage errors
+        });
     }
   });
 
@@ -51,10 +56,15 @@ export default function(channel){
     if (currentQuantity > 0) {
       const credits = getCredits($row);
       const cost    = getCost($row);
-      channel.push('release_stock', { id: $row.data('stock-id'), quantity: 1, type: getType($row) });
-      setUserQuantity($row, currentQuantity - 1);
-      setCredits($row, credits + cost);
-      setTimeout(function(){updateQuantities(getType($row))}, 100);
+      channel.push('release_stock', { id: $row.data('stock-id'), quantity: 1, type: getType($row) })
+        .receive("ok", function() {
+          setUserQuantity($row, currentQuantity - 1);
+          setCredits($row, credits + cost);
+          setTimeout(function(){updateQuantities(getType($row))}, 100);
+        })
+        .receive("error", function() {
+          // TODO: Manage errors
+        });
     }
   });
 

--- a/lib/open_pantry/web/models/stock_distribution.ex
+++ b/lib/open_pantry/web/models/stock_distribution.ex
@@ -54,11 +54,7 @@ defmodule OpenPantry.StockDistribution do
 
   defp per_person_ok?(%StockDistribution{ stock: %Stock{ max_per_person: nil } }, _quantity), do: true
   defp per_person_ok?(stock_distribution, quantity) do
-    if User.is_guest(stock_distribution.user) do
-      quantity <= stock_distribution.stock.max_per_person
-    else
-      quantity <= stock_distribution.stock.max_per_person * stock_distribution.user.family_members
-    end
+    quantity <= stock_distribution.stock.max_per_person * stock_distribution.user.family_members
   end
 
   defp per_package_ok?(%StockDistribution{ stock: %Stock{ max_per_package: nil } }, _quantity), do: true

--- a/lib/open_pantry/web/models/user.ex
+++ b/lib/open_pantry/web/models/user.ex
@@ -49,10 +49,6 @@ defmodule OpenPantry.User do
     |> Repo.one!
   end
 
-  def is_guest(user) do
-    user.family_members == 0
-  end
-
   def facility_stocks(user) do
     Repo.preload(user, :facility).facility
     |> Repo.preload(:stocks)

--- a/lib/open_pantry/web/models/user.ex
+++ b/lib/open_pantry/web/models/user.ex
@@ -49,6 +49,10 @@ defmodule OpenPantry.User do
     |> Repo.one!
   end
 
+  def is_guest(user) do
+    user.family_members == 0
+  end
+
   def facility_stocks(user) do
     Repo.preload(user, :facility).facility
     |> Repo.preload(:stocks)


### PR DESCRIPTION
Fix for issue #108.

When taking care of this issue, I notices some bugs I had to correct : 
- It was possible to add more items than the max_per_package value in the interface, because validation errors on the stock update Ecto.Multi query where ignored silently and never returned to the Javascript code. The query failed, but the interface still thought the item was added successfully.
- The previous bug caused another bug : If we added more items than authorized to the cart, and then we removed them from the cart, the item count would fall into negative values, also increasing the noms and stock amounts past their maximum value.
- The max_per_person validation always failed for guest users, because they have 0 family_members which means we multiplied the max_per_person value by zero.
- The validate_stock_distribution validation used the quantity in the stock_distribution Struct when validating maximum quantities, but this quantity didn't include the current quantity change when using Ecto.Multi. This means I could add 3 item when the max_per_person was set to 2.