### PR TITLE
Add requirement for GUARDIAN_SECRET_KEY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
         * It will cd into assets directory and install npm packages via yarn
         * You can use another postgres, but you may have to manually install postgis
       * run from open_pantry dir `mix do deps.get, ecto.create, ecto.migrate, run priv/repo/seeds.exs`
-      * Expose an env var with some value in your bash config for `GUARDIAN_SECRET_KEY`, e.g. `export GUARDIAN_SECRET_KEY="A not very secret dev only key"`
       * Start Phoenix endpoint with `mix phx.server`, or `iex -S mix phx.server` (this gives a server and REPL/console in one window)
     * Docker/docker-compose (fake, factory generated data but no dependencies)
       * Install docker (on most systems this also installs docker-compose)

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -35,6 +35,9 @@ config :open_pantry, OpenPantry.Web.Endpoint,
                     cd: Path.expand("../assets", __DIR__)]]
 
 
+config :guardian, Guardian,
+  secret_key: "A not very secret dev only key"
+
 # Watch static and templates for browser reloading.
 config :open_pantry, OpenPantry.Web.Endpoint,
   live_reload: [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     command:   mix phx.server
     environment:
       DOCKER: 'true'
-      GUARDIAN_SECRET_KEY: "A not very secret dev only key"
     volumes:
       - .:/app
     ports:

--- a/lib/open_pantry.ex
+++ b/lib/open_pantry.ex
@@ -6,6 +6,10 @@ defmodule OpenPantry do
   def start(_type, _args) do
     import Supervisor.Spec
 
+    if !Application.get_env(:guardian, Guardian)[:secret_key] do
+      raise "GUARDIAN_SECRET_KEY environment variable not set.  It must be set for this application to work correctly"
+    end
+
     # Define workers and child supervisors to be supervised
     children = [
       # Start the Ecto repository

--- a/mix.exs
+++ b/mix.exs
@@ -1,3 +1,7 @@
+if !Map.has_key?(System.get_env(), "GUARDIAN_SECRET_KEY") do
+  raise "GUARDIAN_SECRET_KEY environment variable not set.  It must be set for this application to work correctly"
+end
+
 defmodule OpenPantry.Mixfile do
   use Mix.Project
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,3 @@
-if !Map.has_key?(System.get_env(), "GUARDIAN_SECRET_KEY") do
-  raise "GUARDIAN_SECRET_KEY environment variable not set.  It must be set for this application to work correctly"
-end
-
 defmodule OpenPantry.Mixfile do
   use Mix.Project
 


### PR DESCRIPTION
Very small PR.  This change doesn't let you start the app if the `GUARDIAN_SECRET_KEY` environment variable isn't set.

The `mix.exs` seemed like the place to do it because it's part of the base Elixir app, but I'm happy to put it somewhere else too.