### PR TITLE
[food selection] remove credit-type <span> element

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -11,6 +11,10 @@
   }
 }
 
+.hidden {
+  display: none;
+}
+
 // Layout
 .container {
   display: flex;


### PR DESCRIPTION
seems like the point of mix.lock and package-lock.json are that they shouldn't change if I'm not changing any dependencies?

I can reset them, but figured someone would have run into this before.

visual proof of change :)

[after.pdf](https://github.com/openpantry/open_pantry/files/1742618/after.pdf)
[before.pdf](https://github.com/openpantry/open_pantry/files/1742619/before.pdf)
