### PR TITLE
remove :locale from food selection flow

### DIFF
--- a/lib/open_pantry/web/controllers/food_selection_controller.ex
+++ b/lib/open_pantry/web/controllers/food_selection_controller.ex
@@ -32,13 +32,13 @@ defmodule OpenPantry.Web.FoodSelectionController do
     conn
     |> put_flash(:info, gettext("Your order has been finalized!"))
     |> Plug.Conn.delete_resp_cookie("user_token")
-    |> redirect(to: "/#{conn.assigns.locale || "en" }/")
+    |> redirect(to: "/")
   end
 
   defp handle_result({:error, _changeset}, conn) do
     conn
     |> put_flash(:error, gettext("There was an error updating your order"))
-    |> redirect(to: food_selection_path(conn, :index, conn.assigns.locale))
+    |> redirect(to: food_selection_path(conn, :index))
   end
 
   defp permitted_params(params) do

--- a/lib/open_pantry/web/router.ex
+++ b/lib/open_pantry/web/router.ex
@@ -16,11 +16,6 @@ defmodule OpenPantry.Web.Router do
     plug Plugs.Facility
   end
 
-  pipeline :localized_browser do
-    plug :browser
-    plug Plugs.Locale, "en"
-  end
-
   pipeline :api do
     plug :accepts, ["json"]
   end
@@ -75,20 +70,13 @@ defmodule OpenPantry.Web.Router do
   end
 
   scope "/", OpenPantry.Web do
-    pipe_through [:localized_browser, :browser_auth, :facility_specified] # Use the default browser stack
+    pipe_through [:browser, :browser_auth, :facility_specified, :user_required]
 
-    get "/", PageController, :unused
+    get "/", FoodSelectionController, :index
   end
 
-
-  scope "/:locale", OpenPantry.Web do
-    pipe_through [:localized_browser, :browser_auth, :facility_specified, :user_required]
-
-    get "/", PageController, :index
-  end
-
-  scope "/:locale", OpenPantry.Web do
-    pipe_through [:localized_browser, :facility_specified, :user_required]
+  scope "/", OpenPantry.Web do
+    pipe_through [:browser, :facility_specified, :user_required]
     get "/styleguide", StyleController, :index
     resources "/registrations", RegistrationController
     resources "/food_selections", FoodSelectionController

--- a/lib/open_pantry/web/templates/food_selection/index.html.eex
+++ b/lib/open_pantry/web/templates/food_selection/index.html.eex
@@ -58,7 +58,7 @@
           <%= render SharedView, "distribution.html", distribution: distribution, conn: @conn %>
         <% end %>
       </div>
-      <%= form_for @user_order, food_selection_path(@conn, :update, @conn.assigns.locale, @user_order.data.id), fn f -> %>
+      <%= form_for @user_order, food_selection_path(@conn, :update, @user_order.data.id), fn f -> %>
         <%= hidden_input(f, :finalized, value: true) %>
         <%= submit gettext("Complete your order!") %>
       <% end %>

--- a/lib/open_pantry/web/templates/layout/app.html.eex
+++ b/lib/open_pantry/web/templates/layout/app.html.eex
@@ -28,10 +28,6 @@
     <header class="ui menu">
       <div class="item">
         <%= gettext "Thank you for testing our Beta app!" %> &nbsp;&nbsp;
-
-        <%= unless Map.has_key?(@conn.assigns, :landing_page) do %>
-          <a href="<%= page_path(@conn, :index, @conn.assigns |> Map.get(:locale, "en") ) %>"><%= gettext "Back" %></a>
-        <% end %>
       </div>
 
       <%= if user = Guardian.Plug.current_resource(@conn) do %>

--- a/test/acceptance/food_selection_test.exs
+++ b/test/acceptance/food_selection_test.exs
@@ -10,7 +10,7 @@ defmodule OpenPantry.FoodSelectionTest do
     %{credit_types: [credit_type|_]} = two_credit_facility()
 
     session
-    |> visit(food_selection_url(Endpoint, :index, "en"))
+    |> visit(food_selection_url(Endpoint, :index))
     |> assert_has(css(".#{dasherize(credit_type.name)}", text: credit_type.name))
     |> Wallaby.end_session
   end
@@ -20,7 +20,7 @@ defmodule OpenPantry.FoodSelectionTest do
 
     session
     |> resize_window(2000, 2000)
-    |> visit(food_selection_url(Endpoint, :index, "en"))
+    |> visit(food_selection_url(Endpoint, :index))
     |> click(link(credit_type.name))
     |> take_screenshot
     |> assert_has(css(".#{dasherize(credit_type.name)}-stock-description", text: food.longdesc))
@@ -31,7 +31,7 @@ defmodule OpenPantry.FoodSelectionTest do
     %{credit_types: [credit_type|_], foods: [_|[food2]]} = two_credit_facility()
 
     session
-    |> visit(food_selection_url(Endpoint, :index, "en"))
+    |> visit(food_selection_url(Endpoint, :index))
     |> refute_has(css(".#{dasherize(credit_type.name)}-stock-description", text: food2.longdesc))
     |> Wallaby.end_session
   end
@@ -40,7 +40,7 @@ defmodule OpenPantry.FoodSelectionTest do
     %{credit_types: [_|[credit_type2]], foods: [_|[food2]]} = two_credit_facility()
 
     session
-    |> visit(food_selection_url(Endpoint, :index, "en"))
+    |> visit(food_selection_url(Endpoint, :index))
     |> click(link(credit_type2.name))
     |> assert_has(css(".#{dasherize(credit_type2.name)}-stock-description", text: food2.longdesc))
     |> Wallaby.end_session


### PR DESCRIPTION
this is more of a question than an answer. mostly i'm wondering if we can remove the i18 flow for now as it complicates a bit of the routes and its not totally consistent (for instance, / redirects to /en, which then shows you a language selection page, even though the url is "/en" which clearly implies that we "think" you have already selected english).

instead of fixing that, I just removed the :locale part of the url for the main food_selection flow, which incidentally is the only one that I know how to test.

this works for the food selection flow (ie I can open up openpantry, add some items, click checkout, and then get redirected back to food selection start page). 

I welcome suggestions for more comprehensive testing/a better solution to this problem